### PR TITLE
Update local-preview-playbook.yml

### DIFF
--- a/local-preview-playbook.yml
+++ b/local-preview-playbook.yml
@@ -66,7 +66,7 @@ asciidoc:
     astra-ui: 'Astra Portal'
     astra-url: 'https://astra.datastax.com'
     astra-ui-link: '{astra-url}[{astra-ui}^]'
-    db-classic: 'Managed Cluster'
+    db-classic: 'Astra Managed Clusters'
     db-serverless: 'Serverless (non-vector)'
     db-serverless-vector: 'Serverless (vector)'
     scb: 'Secure Connect Bundle (SCB)'
@@ -216,10 +216,6 @@ asciidoc:
     capacity-service: 'Capacity Service'
     lcm: 'Lifecycle Manager (LCM)'
     lcm-short: 'LCM'
-    cr: 'custom resource (CR)'
-    cr-short: 'CR'
-    crd: 'custom resource definition (CRD)'
-    crd-short: 'CRD'
     # Antora Atlas
     primary-site-url: https://docs.datastax.com/en
     primary-site-manifest-url: https://docs.datastax.com/en/site-manifest.json


### PR DESCRIPTION
- Remove CR/CRD attributes. They are used fewer than 200 times across all the docs, and there are often times when we need to make them plural or initial cap. It isn't a good practice to have pluralized attributes (`{attribute}s`), and having various attributes for different capitalizations/plurals is unnecessary overhead for fewer than 200 uses.
- Update db-classic attribute definition in local preview playbook.